### PR TITLE
[K8S_VERSION_IMPROVEMENT] Refactor Version class method major_minor_v…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kubetest
 
 [![Build Status](https://build.vio.sh/buildStatus/icon?job=vapor-ware/kubetest/master)](https://build.vio.sh/blue/organizations/jenkins/vapor-ware%2Fkubetest/activity)
-<img alt="PyPI" src="https://img.shields.io/badge/pypi-v1.26.4+cnis-orange.svg?cacheSeconds=2592000" />
+<img alt="PyPI" src="https://img.shields.io/badge/pypi-v1.26.9+cnis-orange.svg?cacheSeconds=2592000" />
 [![Documentation Status](https://readthedocs.org/projects/kubetest/badge/?version=latest)](https://kubetest.readthedocs.io/en/latest/?badge=latest)
 
 Kubetest is a [pytest][pytest] plugin that makes it easier to manage a Kubernetes

--- a/kubetest/__init__.py
+++ b/kubetest/__init__.py
@@ -1,7 +1,7 @@
 """kubetest -- a Kubernetes integration test framework in Python."""
 
 __title__ = "kubetest"
-__version__ = "1.26.8+cnis"
+__version__ = "1.26.9+cnis"
 __description__ = "A Kubernetes integration test framework in Python."
 __author__ = "Vapor IO"
 __author_email__ = "vapor@vapor.io"

--- a/kubetest/objects/version.py
+++ b/kubetest/objects/version.py
@@ -43,8 +43,21 @@ class Version(ApiObject):
     def git_version(self):
         return self.obj.git_version
 
-    def major_minor_version(self):
-        return self.obj.major, self.obj.minor
+    def major_minor_version(self, digit_only=False):
+        """
+        :param digit_only:  To parse minor version such as 28+, we keep only the leading part
+        :return: major, minor tuple
+        """
+        minor = ""
+        if digit_only:
+            for char in self.obj.minor:
+                if char.isdigit():
+                    minor += char
+                else:
+                    break  # Stop when a non-digit character is encountered
+        else:
+            minor = self.obj.minor
+        return self.obj.major, minor
 
     def get_version_code(self):
         return Version.preferred_client().get_code()


### PR DESCRIPTION
Refactor Version class method major_minor_version()

- Introduced the `digit_only` parameter for parsing leading digits in minor version.

In the Version class, the major_minor_version() method has been refactored to optionally extract only the leading digits from the minor version string. This change introduces the `digit_only` parameter, allowing parsing of minor versions like "28+". When `digit_only` is enabled, the method iterates through the minor version string and extracts the leading digits until a non-digit character is encountered. This change maintains backward compatibility by returning the complete minor version string when `digit_only` is not used.