### PR TITLE
[KUBERNETES-35-UPLIFT] Update Kubernetes version to v35

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: ['3.9', '3.10', '3.11', '3.12']
+        py-version: ['3.10', '3.11', '3.12', '3.13']
     name: Python ${{ matrix.py-version }} Test
     steps:
     - name: Checkout

--- a/kubetest/objects/storageclass.py
+++ b/kubetest/objects/storageclass.py
@@ -1,7 +1,6 @@
 """Kubetest wrapper for the Kubernetes ``storageClass`` API Object."""
 
 import logging
-from distutils.util import strtobool
 
 from kubernetes import client
 
@@ -57,4 +56,4 @@ class StorageClass(ApiObject):
         flag = self.obj.metadata.annotations.get(
             "storageclass.kubernetes.io/is-default-class", "0"
         )
-        return bool(strtobool(flag.lower()))
+        return flag.lower() in ("y", "yes", "t", "true", "on", "1")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,61 +4,49 @@
 #
 #    pip-compile --output-file=requirements.txt setup.py
 #
-cachetools==5.5.2
-    # via google-auth
-certifi==2025.1.31
+certifi==2026.4.22
     # via
     #   kubernetes
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.7
     # via requests
-durationpy==0.9
+durationpy==0.10
     # via kubernetes
-google-auth==2.38.0
-    # via kubernetes
-idna==3.10
+idna==3.13
     # via requests
-iniconfig==2.0.0
+iniconfig==2.3.0
     # via pytest
-kubernetes==33.1.0
+kubernetes==35.0.0
     # via kubetest (setup.py)
-oauthlib==3.2.2
-    # via
-    #   kubernetes
-    #   requests-oauthlib
-packaging==24.2
+oauthlib==3.3.1
+    # via requests-oauthlib
+packaging==26.2
     # via pytest
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
-pyasn1==0.6.1
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.4.1
-    # via google-auth
-pytest==8.3.5
+pygments==2.20.0
+    # via pytest
+pytest==8.4.2
     # via kubetest (setup.py)
 python-dateutil==2.9.0.post0
     # via kubernetes
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   kubernetes
     #   kubetest (setup.py)
-requests==2.32.3
+requests==2.33.1
     # via
     #   kubernetes
     #   requests-oauthlib
 requests-oauthlib==2.0.0
     # via kubernetes
-rsa==4.9
-    # via google-auth
 six==1.17.0
     # via
     #   kubernetes
     #   python-dateutil
-urllib3==2.3.0
+urllib3==2.7.0
     # via
     #   kubernetes
     #   requests
-websocket-client==1.8.0
+websocket-client==1.9.0
     # via kubernetes

--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,14 @@ setup(
     author_email=pkg["__author_email__"],
     license=pkg["__license__"],
     packages=find_packages(),
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     package_data={
         "": ["LICENSE"],
     },
     install_requires=[
-        "kubernetes>=33, <34",
+        "kubernetes>=35, <36",
         "pyyaml>=5.4",
-        "pytest",
+        "pytest<9",
     ],
     zip_safe=False,
     classifiers=[
@@ -46,11 +46,10 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     # this make a plugin available to pytest
     # https://docs.pytest.org/en/latest/writing_plugins.html#making-your-plugin-installable-by-others

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
-envlist=py{38,39,310,311,312},deps,docs,examples
+envlist=py{310,311,312,313},deps,docs,examples
 skip_missing_interpreters=True
 
 
 [gh-actions]
 python =
-    3.8: py38,lint
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 
 
@@ -17,10 +16,8 @@ python =
 description=
     run tests with pytest under {basepython}
 deps=
-    pip-tools
 commands=
-    pip-sync {toxinidir}/requirements.txt {toxinidir}/requirements-test.txt
-    pip install -e .
+    pip install -r {toxinidir}/requirements.txt -r {toxinidir}/requirements-test.txt -e {toxinidir}
 
     ; instead of running pytest with the pytest-cov plugin, we need
     ; to run coverage against pytest as seen below. this is because


### PR DESCRIPTION
## Summary

- Bump \`kubernetes\` Python library dependency from \`>=33, <34\` to \`>=35, <36\`
- Cap \`pytest\` to \`<9\` to stay on the 8.x series
- Regenerate \`requirements.txt\` with latest pinned versions (kubernetes 35.0.0 drops google-auth, pyasn1, rsa as direct deps)
- No breaking API changes in kubernetes 35.0.0
- Drop Python 3.8/3.9 support; add Python 3.13 (\`python_requires\` bumped to \`>=3.10\`)
- Replace \`pip-sync\` in \`[testenv]\` with plain \`pip install -r\` to fix compatibility with pip 26+ on GitHub Actions runners
- Fix \`ModuleNotFoundError: No module named 'distutils'\` in \`storageclass.py\` (distutils removed in Python 3.12; replaced \`strtobool\` with an inline equivalent)

## Test plan

- [x] All unit tests pass (\`pytest tests/\` — 116 passed)