### PR TITLE
[GATEWAY_API] Add HTTPRoute support for Kubernetes Gateway API

### DIFF
--- a/kubetest/client.py
+++ b/kubetest/client.py
@@ -1474,6 +1474,59 @@ class TestClient:
 
         return ingresses
 
+    def get_httproutes(
+        self,
+        namespace: str = None,
+        all_namespaces: bool = False,
+        fields: Dict[str, str] = None,
+        labels: Dict[str, str] = None,
+    ) -> Dict[str, objects.HTTPRoute]:
+        """Get HTTPRoute resources from the cluster (Kubernetes Gateway API).
+
+        Args:
+            namespace: The namespace to get HTTPRoutes from. If not specified,
+                uses the auto-generated test case namespace by default.
+            all_namespaces: If True, list HTTPRoutes from all namespaces.
+            fields: A dictionary of fields used to restrict the returned collection.
+            labels: A dictionary of labels used to restrict the returned collection.
+
+        Returns:
+            A dictionary where the key is the HTTPRoute name (or a (name, namespace)
+            tuple if all_namespaces=True) and the value is the HTTPRoute object.
+        """
+        if namespace and len(namespace) > 0 and all_namespaces:
+            raise AttributeError("Can not set namespace when all_namespaces=True")
+
+        selectors = utils.selector_kwargs(fields, labels)
+        preferred_client = objects.HTTPRoute.preferred_client(
+            api_client=self.api_client
+        )
+
+        group = objects.HTTPRoute.GATEWAY_API_GROUP
+        version = objects.HTTPRoute.GATEWAY_API_VERSION
+        plural = objects.HTTPRoute.GATEWAY_API_PLURAL
+
+        if all_namespaces:
+            results = preferred_client.list_cluster_custom_object(
+                group, version, plural, **selectors
+            )
+        else:
+            if namespace is None:
+                namespace = self.namespace
+            results = preferred_client.list_namespaced_custom_object(
+                group, version, namespace, plural, **selectors
+            )
+
+        httproutes = {}
+        for obj in results["items"]:
+            httproute = objects.HTTPRoute(obj, api_client=self.api_client)
+            httproutes[
+                (httproute.name, httproute.namespace)
+                if all_namespaces
+                else httproute.name
+            ] = httproute
+        return httproutes
+
     def get_replicasets(
         self,
         namespace: str = None,

--- a/kubetest/objects/__init__.py
+++ b/kubetest/objects/__init__.py
@@ -14,6 +14,7 @@ from .daemonset import DaemonSet
 from .deployment import Deployment
 from .endpoints import Endpoints
 from .event import Event
+from .httproute import HTTPRoute
 from .ingress import Ingress
 from .job import Job
 from .namespace import Namespace

--- a/kubetest/objects/httproute.py
+++ b/kubetest/objects/httproute.py
@@ -1,0 +1,49 @@
+"""Kubetest wrapper for the Kubernetes ``HTTPRoute`` Gateway API Object."""
+
+import logging
+
+from kubernetes import client
+
+from .custom_objects import CustomObject
+
+log = logging.getLogger("kubetest")
+
+
+class HTTPRoute(CustomObject):
+    """Kubetest wrapper around a Kubernetes HTTPRoute Gateway API object.
+
+    HTTPRoute is part of the Kubernetes Gateway API (gateway.networking.k8s.io/v1)
+    and is the successor to Ingress in clusters using the Gateway API.
+
+    The raw dict returned by the Kubernetes API is accessible via ``obj``.
+    """
+
+    GATEWAY_API_GROUP = "gateway.networking.k8s.io"
+    GATEWAY_API_VERSION = "v1"
+    GATEWAY_API_PLURAL = "httproutes"
+
+    api_clients = {
+        "preferred": client.CustomObjectsApi,
+        "gateway.networking.k8s.io/v1": client.CustomObjectsApi,
+        "gateway.networking.k8s.io/v1beta1": client.CustomObjectsApi,
+    }
+
+    def __init__(self, api_object, api_client=None):
+        super().__init__(
+            api_object,
+            group=self.GATEWAY_API_GROUP,
+            version=self.GATEWAY_API_VERSION,
+            plural=self.GATEWAY_API_PLURAL,
+            api_client=api_client,
+        )
+
+    @property
+    def hostnames(self) -> list:
+        """All hostnames defined in the HTTPRoute spec."""
+        return self.obj.get("spec", {}).get("hostnames", [])
+
+    @property
+    def hostname(self) -> str | None:
+        """The first hostname defined in the HTTPRoute spec, or None."""
+        hostnames = self.hostnames
+        return hostnames[0] if hostnames else None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-universal = 1
+python-tag = py3
 
 [isort]
 profile = black


### PR DESCRIPTION
Adds HTTPRoute object and get_httproutes() client method for querying Gateway API HTTPRoute resources, mirroring the existing Ingress pattern.